### PR TITLE
Added potions for health, damage, speed, and slow

### DIFF
--- a/BluePotion.cpp
+++ b/BluePotion.cpp
@@ -1,0 +1,53 @@
+/**
+	Class: BluePotion
+	Inherits: Collectibles
+	Purpose: A blue potion that slows the player.
+
+	Made for CIS343 @ GVSU Fall 2018
+	Team Members:
+	Isfar Baset
+	Aliision Bickford
+	Nick Cone
+	Farid Karadsheh
+
+*/
+
+#include "SFML/Graphics.hpp"
+#include "include/Collectibles.hpp"
+#include "include/Person.hpp"
+#include <iostream>
+
+class BluePotion: public Collectibles {
+public:
+	/* Default Constructor, loads sprite and uses default (x,y) coordinates
+	   set in Collectibles. */
+	BluePotion() {
+		loadSprite("sprites/bluePotion.png");
+	}
+	
+	/* Loads in the sprite, and accepts (x,y) cooridnates, so that it may be
+	   placed anywhere in the game world. */
+	BluePotion(int x , int y) {
+		this->x = x;
+		this->y = y;
+		loadSprite("sprites/bluePotion.png");
+	}
+
+
+	/* Modifies the player speed by 0.8, slowing the player down temporarily. */
+	void activate(Person &person) {
+		//slow the character
+		hasActivated = true;
+	}
+
+	/* After aproximately 5 seconds, return the player to normal speed. */
+	void deactivate(Person &person) {
+	  	 sf::Time time = clock.getElapsedTime();
+                 sf::Int32 mills = time.asMilliseconds();
+                 if(mills % 5000 > 500) {
+                         //speed up character
+                 
+		 }
+		hasDeactivated = true;
+	}
+ };

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,131 @@
+cmake_minimum_required(VERSION 3.12)
+project(gv343_game_section1)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(include)
+include_directories(SFML)
+include_directories(SFML/Audio)
+include_directories(SFML/Graphics)
+include_directories(SFML/Network)
+include_directories(SFML/System)
+include_directories(SFML/Window)
+
+add_executable(gv343_game_section1
+        include/Collision.hpp
+        include/Game.hpp
+        include/Monster.hpp
+        include/Person.hpp
+        include/Settings.hpp
+        SFML/Audio/AlResource.hpp
+        SFML/Audio/Export.hpp
+        SFML/Audio/InputSoundFile.hpp
+        SFML/Audio/Listener.hpp
+        SFML/Audio/Music.hpp
+        SFML/Audio/OutputSoundFile.hpp
+        SFML/Audio/Sound.hpp
+        SFML/Audio/SoundBuffer.hpp
+        SFML/Audio/SoundBufferRecorder.hpp
+        SFML/Audio/SoundFileFactory.hpp
+        SFML/Audio/SoundFileFactory.inl
+        SFML/Audio/SoundFileReader.hpp
+        SFML/Audio/SoundFileWriter.hpp
+        SFML/Audio/SoundRecorder.hpp
+        SFML/Audio/SoundSource.hpp
+        SFML/Audio/SoundStream.hpp
+        SFML/Graphics/BlendMode.hpp
+        SFML/Graphics/CircleShape.hpp
+        SFML/Graphics/Color.hpp
+        SFML/Graphics/ConvexShape.hpp
+        SFML/Graphics/Drawable.hpp
+        SFML/Graphics/Export.hpp
+        SFML/Graphics/Font.hpp
+        SFML/Graphics/Glsl.hpp
+        SFML/Graphics/Glsl.inl
+        SFML/Graphics/Glyph.hpp
+        SFML/Graphics/Image.hpp
+        SFML/Graphics/PrimitiveType.hpp
+        SFML/Graphics/Rect.hpp
+        SFML/Graphics/Rect.inl
+        SFML/Graphics/RectangleShape.hpp
+        SFML/Graphics/RenderStates.hpp
+        SFML/Graphics/RenderTarget.hpp
+        SFML/Graphics/RenderTexture.hpp
+        SFML/Graphics/RenderWindow.hpp
+        SFML/Graphics/Shader.hpp
+        SFML/Graphics/Shape.hpp
+        SFML/Graphics/Sprite.hpp
+        SFML/Graphics/Text.hpp
+        SFML/Graphics/Texture.hpp
+        SFML/Graphics/Transform.hpp
+        SFML/Graphics/Transformable.hpp
+        SFML/Graphics/Vertex.hpp
+        SFML/Graphics/VertexArray.hpp
+        SFML/Graphics/VertexBuffer.hpp
+        SFML/Graphics/View.hpp
+        SFML/Network/Export.hpp
+        SFML/Network/Ftp.hpp
+        SFML/Network/Http.hpp
+        SFML/Network/IpAddress.hpp
+        SFML/Network/Packet.hpp
+        SFML/Network/Socket.hpp
+        SFML/Network/SocketHandle.hpp
+        SFML/Network/SocketSelector.hpp
+        SFML/Network/TcpListener.hpp
+        SFML/Network/TcpSocket.hpp
+        SFML/Network/UdpSocket.hpp
+        SFML/System/Clock.hpp
+        SFML/System/Err.hpp
+        SFML/System/Export.hpp
+        SFML/System/FileInputStream.hpp
+        SFML/System/InputStream.hpp
+        SFML/System/Lock.hpp
+        SFML/System/MemoryInputStream.hpp
+        SFML/System/Mutex.hpp
+        SFML/System/NativeActivity.hpp
+        SFML/System/NonCopyable.hpp
+        SFML/System/Sleep.hpp
+        SFML/System/String.hpp
+        SFML/System/String.inl
+        SFML/System/Thread.hpp
+        SFML/System/Thread.inl
+        SFML/System/ThreadLocal.hpp
+        SFML/System/ThreadLocalPtr.hpp
+        SFML/System/ThreadLocalPtr.inl
+        SFML/System/Time.hpp
+        SFML/System/Utf.hpp
+        SFML/System/Utf.inl
+        SFML/System/Vector2.hpp
+        SFML/System/Vector2.inl
+        SFML/System/Vector3.hpp
+        SFML/System/Vector3.inl
+        SFML/Window/Clipboard.hpp
+        SFML/Window/Context.hpp
+        SFML/Window/ContextSettings.hpp
+        SFML/Window/Cursor.hpp
+        SFML/Window/Event.hpp
+        SFML/Window/Export.hpp
+        SFML/Window/GlResource.hpp
+        SFML/Window/Joystick.hpp
+        SFML/Window/Keyboard.hpp
+        SFML/Window/Mouse.hpp
+        SFML/Window/Sensor.hpp
+        SFML/Window/Touch.hpp
+        SFML/Window/VideoMode.hpp
+        SFML/Window/Window.hpp
+        SFML/Window/WindowHandle.hpp
+        SFML/Window/WindowStyle.hpp
+        SFML/Audio.hpp
+        SFML/Config.hpp
+        SFML/GpuPreference.hpp
+        SFML/Graphics.hpp
+        SFML/Main.hpp
+        SFML/Network.hpp
+        SFML/OpenGL.hpp
+        SFML/System.hpp
+        SFML/Window.hpp
+        Collision.cpp
+        Game.cpp
+        main.cpp
+        Monster.cpp
+        Person.cpp)

--- a/GreenPotion.cpp
+++ b/GreenPotion.cpp
@@ -1,0 +1,34 @@
+#include "SFML/Graphics.hpp"
+#include "include/Collectibles.hpp"
+#include "include/Person.hpp"
+#include <iostream>
+
+/************************************************************************
+ * This is the green potion that speeds up the player
+ * 
+ * @author Team Collectibles
+ * @version October 6, 2018
+ ************************************************************************/
+ class GreenPotion: public Collectibles{
+     public:
+
+     GreenPotion(){
+	 // loading the potion image 
+         loadSprite("sprites/greenPotion.png");
+     }
+     
+     // positioning the image 
+     GreenPotion(int x, int y): Collectibles(){
+         this->x = x;
+         this->y = y;
+         loadSprite("sprites/greenPotion.png");
+     }
+
+     // activates the collectible and speeds up the player if it is hit
+     void activate(Person &person){
+        
+	     //speed up
+         
+	     hasActivated = true;
+     }
+ };

--- a/OrangePotion.cpp
+++ b/OrangePotion.cpp
@@ -1,0 +1,42 @@
+/**
+	Class: OrangePotion
+	Inherits: Collectibles
+	Purpose: An orange potion that heals the player.
+
+	Made for CIS343 @ GVSU Fall 2018
+	Team Members:
+	Isfar Baset
+	Allision Bickford
+	Nick Cone
+	Farid Karadsheh
+
+*/
+
+#include "include/Collectibles.hpp"
+#include "include/Collision.hpp"
+#include <stdio.h>
+
+class OrangePotion: public Collectibles {
+public:
+	/* Default constructor, loads sprite and uses default (x,y) coordinates
+	   set in Collectibles */
+	OrangePotion() {
+		loadSprite("sprites/orangePoition.png");	
+	}
+
+	/* Loads in the sprite, and accepts (x,y) coordinates, so that it may be
+	   placed anywhere in the game world. */
+	OrangePotion(int x, int y) {
+		this->x = x;
+		this->y = y;
+		loadSprite("sprites/orangePoition.png");
+	}
+
+	/* Heals the player by 50 hp to a maximum of 100 hp. */
+	void activate(Person &person){
+		int health = person.getHealth();
+		if(health <= 50) person.setHealth(health+50);
+		else person.setHealth(100);
+		hasActivated = true;
+	}
+};

--- a/YellowPotion.cpp
+++ b/YellowPotion.cpp
@@ -1,0 +1,26 @@
+#include "include/Collectibles.hpp"
+#include "include/Collision.hpp"
+#include <stdio.h>
+
+//@Author Nicholas Cone
+//@Version October 8th, 2018
+class YellowPotion: public Collectibles{
+	public:
+	//loads in image of yellow potion
+		YellowPotion(){
+			loadSprite("sprites/yellowPoition.png");
+		}
+		//Allows user to update position of collectible
+		YellowPotion(int x, int y): Collectibles(){
+
+			this->x = x;
+			this->y = y;
+			loadSprite("sprites/yellowPoition.png");
+		}
+	//Activates the collectible to remove 20 damage everytime it is hit.
+		void activate(Person &person){
+			int h = person.getHealth();
+			person.setHealth(h-20);
+			hasActivated = true;
+		}
+};

--- a/include/Collectibles.hpp
+++ b/include/Collectibles.hpp
@@ -1,0 +1,108 @@
+/**
+	Class: Collectibles
+	Purpose: Acts as a parent to specific colllectible items. This class
+	is not intended to be instantiated.
+
+	Made for CIS343 @ GVSU Fall 2018
+	Team Members:
+	Isfar Baset
+	Allision Bickford
+	Nick Cone
+	Farid Karadsheh
+
+*/
+#ifndef H__COLLECTIBLES__
+#define H__COLLECTIBLES__
+
+#include "SFML/Graphics.hpp"
+#include "SFML/System/Clock.hpp"
+#include "SFML/Window.hpp"
+#include "Collision.hpp"
+#include "Person.hpp"
+#include <string.h>
+#include <stdio.h>
+
+class Collectibles {
+public:
+
+	/* Detects collision with a player. */
+	bool detectCollision(Person &person) {
+		return Collision::BoundingBoxTest(person.getSprite(), this->sprite);
+	}
+
+	/* Moves the collectible up and down. */
+	void move() {
+		sf::Time time = clock.getElapsedTime();
+		sf::Int32 mills = time.asMilliseconds();
+		if(mills % 1000 > 500) {
+			y += bounce;
+			sprite.setPosition(x, y);
+			bounce *= -1;
+			clock.restart();
+		}
+	}
+	
+	/* When colliding with player, activate the collectibles powers.
+	Collision detection is not handled here. */
+	virtual void activate(Person &person) = 0;
+
+	/* Loads sprite to sprite field. */
+	void loadSprite(const std::string filename) {
+		if(!texture.loadFromFile(filename)) {
+			printf("Failed to load texture: %s\n", filename.c_str());
+			exit(EXIT_FAILURE);
+		}
+		sprite.setTexture(texture);
+		sf::FloatRect spriteSize = sprite.getGlobalBounds();
+		sprite.setOrigin(spriteSize.width/2.0, spriteSize.height/2.0);
+		sprite.setPosition(x,y);
+	}
+	
+	/* Will be called each frame. Checks flags, calls move(), and 
+	(de)activates if neccessary. */
+	void update(Person &person) {
+		if(!hasActivated){
+			if(detectCollision(person))
+				activate(person);
+
+		}
+		if(!hasDeactivated && hasActivated){ 
+			deactivate(person);
+		}
+		move();
+	}
+
+	/* Recieves game's window, then draws the collectible. */
+	void render(sf::RenderWindow &window) {
+		if(!hasActivated)
+			window.draw(sprite);
+	}
+	
+	/* After an elapsed time, a collectible will deactivate.
+	   Not all collectibles have effects that need to be deactivated. */
+	void deactivate(Person &person){}
+	
+	/* Returns sprite. */
+	sf::Sprite getSprite() {
+		return this->sprite;
+	}
+
+protected:
+	/* Sprite for dimensions, collisions, and rendering. */
+	sf::Sprite sprite;
+	/* Texture that is loaded into the sprite. */
+	sf::Texture texture;
+	/* (x,y) coordinates for positioning. Default coordinates (300, 300)*/
+	int x = 300;
+	int y = 300;
+	/* Height for bounce animation */
+	int bounce = 1;
+	/* Flags - When the collectible is picked up, it activates.
+	When the collectible is no longer in use, it deactivates */
+	bool hasActivated = false;
+	bool hasDeactivated = false;
+	/* Clock for animation and deactivation. */
+	sf::Clock clock;
+};
+
+#endif


### PR DESCRIPTION
Speed and slow currently do not work as there is no way to implement them. It would require a way to modify the movement of Person. The health and trap potions work. Also created a header file for Collectibles. Each potion has its own class file.

- Orange Potion: Gain 50 health
- Yellow Potion: Deal 20 damage
- Green Potion: 120% Speed for 5 seconds
- Blue Potion: 80% Speed for 5 seconds
